### PR TITLE
Implemented Repository discovery feature and tests

### DIFF
--- a/src/backend/app/services/analyzers.py
+++ b/src/backend/app/services/analyzers.py
@@ -1,34 +1,15 @@
 from pathlib import Path
-from typing import Dict, Any
-
-def analyze_image(path: Path) -> Dict[str, Any]:
-    # Placeholder image analysis - return basic metadata
-    return {"type": "image", "path": str(path), "size": path.stat().st_size}
-
-def analyze_content(path: Path) -> Dict[str, Any]:
-    # Placeholder content analysis (text/word)
-    try:
-        text = path.read_text(errors="ignore")
-        length = len(text)
-    except Exception:
-        length = None
-    return {"type": "content", "path": str(path), "length": length}
-
-def analyze_code(path: Path) -> Dict[str, Any]:
-    # Placeholder code analysis - return simple metrics
-    try:
-        text = path.read_text(errors="ignore")
-        lines = text.count("\n") + 1
-    except Exception:
-        lines = None
-    return {"type": "code", "path": str(path), "lines": lines}
-from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+import os
 
 
 def analyze_image(path: Path) -> Dict[str, Any]:
     # Placeholder image analysis - return basic metadata
-    return {"type": "image", "path": str(path), "size": path.stat().st_size}
+    try:
+        size = path.stat().st_size
+    except Exception:
+        size = None
+    return {"type": "image", "path": str(path), "size": size}
 
 
 def analyze_content(path: Path) -> Dict[str, Any]:
@@ -49,3 +30,64 @@ def analyze_code(path: Path) -> Dict[str, Any]:
     except Exception:
         lines = None
     return {"type": "code", "path": str(path), "lines": lines}
+
+
+def discover_git_projects(root: Path) -> Dict[Path, int]:
+    """Scan `root` for `.git` directories. Return a mapping of project_root -> tag_id.
+
+    The project_root is the directory that contains the `.git` folder (i.e. the repository root).
+    Tags are assigned sequentially starting at 1 in discovery order.
+    """
+    projects: Dict[Path, int] = {}
+    tag = 1
+    for dirpath, dirnames, _ in os.walk(root):
+        # Look for a `.git` subdirectory
+        if ".git" in dirnames:
+            project_root = Path(dirpath)
+            # Normalize path for consistent comparisons
+            project_root = project_root.resolve()
+            if project_root not in projects:
+                projects[project_root] = tag
+                tag += 1
+            # avoid descending into `.git` itself
+            try:
+                dirnames.remove(".git")
+            except ValueError:
+                pass
+    return projects
+
+
+def find_project_tag_for_path(path: Path, projects: Dict[Path, int]) -> Optional[int]:
+    """Given a file `path` and a dict of project roots -> tag, return the tag for the nearest ancestor project.
+
+    If the file is not under any discovered project root, return None.
+    """
+    path = path.resolve()
+    best_tag: Optional[int] = None
+    best_len = -1
+
+    # Match any project root that is an ancestor of the path (this includes .git children)
+    # Use Path.is_relative_to when available for clarity and performance.
+    for root, tag in projects.items():
+        try:
+            try:
+                is_rel = path.is_relative_to(root)
+            except AttributeError:
+                # Python <3.9 fallback
+                try:
+                    path.relative_to(root)
+                    is_rel = True
+                except Exception:
+                    is_rel = False
+
+            if is_rel:
+                # choose the deepest (longest) matching root
+                l = len(str(root))
+                if l > best_len:
+                    best_len = l
+                    best_tag = tag
+        except Exception:
+            # ignore any filesystem/permission errors and continue
+            continue
+
+    return best_tag

--- a/src/backend/app/views/uploadFolderView.py
+++ b/src/backend/app/views/uploadFolderView.py
@@ -13,8 +13,11 @@ import importlib
 # These are the categories that a file will be classified as based off its extension
 # The current system is expecting a zip files to be uploaded
 # After these are scanned they would get sent to a respective analyzer
-# What's currently missing is a way for multiple files to be categorized as a project, this just analyzes all file types individually.
-# In it's state it can check for nested files as well.
+# Currently, it can only distinguish between repositories by searching them for a ".git" folder.
+# Anything found within that folder would be tagged as part of that repository.
+# Found projects are given two tags, one that is numeric (project_tag) and one that is human-readable (project_root).
+# Project tag is increased sequentially starting at 1 for each discovered repository.
+# Anything found outside of any .git folder would not receive a project tag.
 
 EXT_IMAGE = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff"}
 EXT_CODE = {
@@ -91,6 +94,9 @@ class UploadFolderView(APIView):
             with zipfile.ZipFile(archive_path, "r") as z:
                 z.extractall(tmpdir)
 
+            # Discover git projects under the extracted tree so files can be tagged
+            projects = analyzers.discover_git_projects(tmpdir_path)
+
             for root, _, files in os.walk(tmpdir):
                 for fname in files:
                     fpath = Path(root) / fname
@@ -114,12 +120,57 @@ class UploadFolderView(APIView):
                     # Normalize path to be relative to the extracted tmpdir so we don't leak absolute temp paths
                     try:
                         rel = fpath.relative_to(tmpdir_path)
-                        res["path"] = str(rel)
+                        # Normalize to POSIX-style path (forward slashes) for consistent matching
+                        res["path"] = Path(rel).as_posix()
                     except Exception:
                         # Fallback: use the filename only
                         res.setdefault("path", fname)
 
                     results.append(res)
+
+            # Post-process results to assign project tags.
+            # Prefer using the authoritative `projects` mapping discovered earlier
+            # (project_root Path -> numeric tag). Build a tag->relative-root mapping
+            # and use it to assign both numeric `project_tag` and human-readable
+            # `project_root` to results. If `projects` is empty, fall back to the
+            # previous heuristic that parsed '/.git/' from result paths.
+            projects_rel = {}
+            if projects:
+                for root_path, tag in projects.items():
+                    try:
+                        rel_root = root_path.relative_to(tmpdir_path)
+                        root_str = Path(rel_root).as_posix()
+                    except Exception:
+                        # If relative conversion fails, fall back to the resolved path string
+                        root_str = str(root_path)
+                    projects_rel[tag] = root_str
+
+                # assign tags using projects_rel
+                for r in results:
+                    p = r.get("path", "")
+                    for tag, root_str in projects_rel.items():
+                        if p == root_str or p.startswith(root_str + "/"):
+                            r["project_tag"] = tag
+                            r["project_root"] = root_str
+                            break
+            else:
+                # Fallback heuristic: detect '.git' mentions in paths and assign root string as tag
+                project_roots = []
+                for r in results:
+                    p = r.get("path", "")
+                    if "/.git/" in p or p.endswith("/.git") or p.endswith("/.git/HEAD"):
+                        root = p.split("/.git/")[0] if "/.git/" in p else p.rsplit("/", 1)[0]
+                        if root not in project_roots:
+                            project_roots.append(root)
+
+                for r in results:
+                    p = r.get("path", "")
+                    for root in project_roots:
+                        if p == root or p.startswith(root + "/"):
+                            # for fallback we only have root string; set both fields to it
+                            r["project_tag"] = root
+                            r["project_root"] = root
+                            break
 
         return JsonResponse({"results": results})
 

--- a/tests/test_upload_folder.py
+++ b/tests/test_upload_folder.py
@@ -72,3 +72,101 @@ class UploadFolderTests(TestCase):
         self.assertTrue(any("deep.txt" in p for p in paths))
         self.assertTrue(any("script.js" in p for p in paths))
         self.assertTrue(any("image.jpg" in p for p in paths))
+
+    # Tests that files inside a single git repo get a project_tag and are the same tag
+    def test_project_tag_single_repo(self):
+        files = {
+            # place a .git directory marker and some files under repo/
+            "repo/.git/HEAD": "ref: refs/heads/main",
+            "repo/README.md": "repo readme",
+            "repo/src/main.py": "print('hello')",
+            "other/file.txt": "outside",
+        }
+        zip_bytes = self.make_zip_bytes(files)
+        upload = SimpleUploadedFile("repo.zip", zip_bytes, content_type="application/zip")
+        resp = self.client.post("/api/upload-folder/", {"file": upload})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        # collect project tags for files under repo/
+        repo_tags = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("repo/") and ".git/" not in item.get("path", "")
+        }
+
+        # files in repo should have a tag and all the same tag
+        self.assertTrue(len(repo_tags) == 1, f"Expected one tag for repo files, got {repo_tags}")
+        self.assertIsNotNone(next(iter(repo_tags)))
+        
+        git_tags = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("repo/.git/")
+        }
+        self.assertTrue(all(tag is not None for tag in git_tags))
+        # Also ensure project_root is present for repo files
+        repo_roots = {
+            item.get("project_root")
+            for item in data["results"]
+            if item.get("path", "").startswith("repo/") and ".git/" not in item.get("path", "")
+        }
+        self.assertTrue(len(repo_roots) == 1)
+        self.assertIsNotNone(next(iter(repo_roots)))
+
+    # Tests that multiple repos get different project tags
+    def test_project_tag_multiple_repos(self):
+        files = {
+            "r1/.git/HEAD": "ref: refs/heads/main",
+            "r1/a.txt": "one",
+            "r2/.git/HEAD": "ref: refs/heads/main",
+            "r2/b.txt": "two",
+            "r1/sub/c.py": "print(1)",
+            "r2/sub/d.py": "print(2)",
+        }
+        zip_bytes = self.make_zip_bytes(files)
+        upload = SimpleUploadedFile("multi.zip", zip_bytes, content_type="application/zip")
+        resp = self.client.post("/api/upload-folder/", {"file": upload})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        r1_tags = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("r1/") and ".git/" not in item.get("path", "")
+        }
+        r2_tags = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("r2/") and ".git/" not in item.get("path", "")
+        }
+
+        # Each repo should have at least one tag, and those tags should not be the same
+        self.assertTrue(len(r1_tags) == 1, f"Expected one tag for r1, got {r1_tags}")
+        self.assertTrue(len(r2_tags) == 1, f"Expected one tag for r2, got {r2_tags}")
+        self.assertNotEqual(next(iter(r1_tags)), next(iter(r2_tags)))
+
+        git_tags_r1 = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("r1/.git/")
+        }
+        git_tags_r2 = {
+            item.get("project_tag")
+            for item in data["results"]
+            if item.get("path", "").startswith("r2/.git/")
+        }
+        self.assertTrue(all(tag is not None for tag in git_tags_r1))
+        self.assertTrue(all(tag is not None for tag in git_tags_r2))
+        # Ensure project_root exists and differs for r1 and r2 files
+        r1_roots = {
+            item.get("project_root")
+            for item in data["results"]
+            if item.get("path", "").startswith("r1/") and ".git/" not in item.get("path", "")
+        }
+        r2_roots = {
+            item.get("project_root")
+            for item in data["results"]
+            if item.get("path", "").startswith("r2/") and ".git/" not in item.get("path", "")
+        }
+        self.assertTrue(len(r1_roots) == 1)
+        self.assertTrue(len(r2_roots) == 1)
+        self.assertNotEqual(next(iter(r1_roots)), next(iter(r2_roots)))


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

I further expanded on the file upload and categorization feature from last week. Currently the upload scanner searched for a ".git" folder that is present in cloned repositories. When found it assigns the anything found in the root folder with two tags. One that is incremental based off how many repositories are found, the other is a tag of the root of the repository.

**Closes:** # (issue number)
#58 
---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [X] Test A Once the server is up and running based off the backend readme you are able to navigated to http://127.0.0.1:8000/ once there, a link to go to the file upload test will be present or you can navigate to http://127.0.0.1:8000/api/upload-folder/ directly. Create a zip file on your system containing two cloned repositories. upload the file to the backend server and it will return with a list of the files found within a repository and their unique tag based off the found repository.

- [X] Test B In a separate terminal recreate the steps to start the backend but stop short of the mange.py runserver. Enter python src/backend/manage.py test and the unit tests from our test folder will be run.

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="403" height="121" alt="RepoDiscovery" src="https://github.com/user-attachments/assets/32f51c39-d64b-4b7c-a75f-31
<img width="483" height="127" alt="RepoDiscovery2" src="https://github.com/user-attachments/assets/637bdc36-0e1e-42c5-ab4d-8a2a991809da" />
a0cd35c970" />

This is the expected outcome when two repos are uploaded in a zip folder. The repo project root tag will be distinct based off what you use to test feature
