### PR TITLE
[bugfix] portfolio private error

### DIFF
--- a/src/frontend/src/app/portfolios/[id]/page.js
+++ b/src/frontend/src/app/portfolios/[id]/page.js
@@ -122,6 +122,42 @@ export default function PortfolioDetailPage() {
     );
   }
 
+  if (portfolio && portfolio.is_private) {
+    return (
+      <>
+        <Header />
+        <div className="min-h-screen p-8">
+          <div className="max-w-4xl mx-auto">
+            <div className="bg-[var(--card-bg)] rounded-lg p-8 text-center" style={{ border: '1px solid #27272a' }}>
+              <div className="w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center" style={{ background: 'rgba(79, 124, 247, 0.1)' }}>
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#4f7cf7" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                </svg>
+              </div>
+              <h2 className="text-2xl font-semibold text-white mb-2">Private Portfolio</h2>
+              <p className="text-white/60 mb-1">
+                <span className="font-medium text-white">{portfolio.portfolio_title}</span>
+              </p>
+              {portfolio.owner && (
+                <p className="text-white/50 text-sm mb-6">by {portfolio.owner}</p>
+              )}
+              <p className="text-white/50 text-sm mb-6">
+                The owner has set this portfolio to private. It is not available for public viewing.
+              </p>
+              <Link
+                href="/portfolios"
+                className="inline-block px-4 py-2 bg-white/10 hover:bg-white/20 text-white rounded-lg transition-colors"
+              >
+                Back to Portfolios
+              </Link>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+
   if (error && !portfolio) {
     return (
       <>


### PR DESCRIPTION
## 📝 Description

Previously private portfolios would show an error if they were private and accessed by non auth account. This PR fixes the nextjs error and handles nicer by providing a private portfolio error code.

**Closes:** #285 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- try to make a portfolio then access the link on incognito browser
- ```docker exec capstone_backend python -m pytest tests/test_portfolio_endpoints.py -v```
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="935" height="423" alt="image" src="https://github.com/user-attachments/assets/ba468fd6-b98c-4ece-ab01-f5fbef8e45fb" />