### PR TITLE
[bugfix] auth refresh redirects to login fix

### DIFF
--- a/src/frontend/src/app/dashboard/page.js
+++ b/src/frontend/src/app/dashboard/page.js
@@ -10,7 +10,7 @@ import config from '@/config';
 
 export default function DashboardPage() {
   const router = useRouter();
-  const { isAuthenticated, token, user, setCurrentUser } = useAuth();
+  const { isAuthenticated, token, user, setCurrentUser, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState([]);
   const [skills, setSkills] = useState({
@@ -19,6 +19,7 @@ export default function DashboardPage() {
   });
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -76,7 +77,7 @@ export default function DashboardPage() {
     };
 
     fetchData();
-  }, []);
+  }, [authLoading, isAuthenticated, token, router]);
 
   if (loading) {
     return (

--- a/src/frontend/src/app/login/page.js
+++ b/src/frontend/src/app/login/page.js
@@ -10,15 +10,19 @@ import { initializeButtons } from '@/utils/buttonAnimation';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login: authLogin } = useAuth();
+  const { login: authLogin, isAuthenticated, loading: authLoading } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      router.push('/dashboard');
+      return;
+    }
     initializeButtons();
-  }, []);
+  }, [authLoading, isAuthenticated, router]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/src/frontend/src/app/portfolios/[id]/edit/page.js
+++ b/src/frontend/src/app/portfolios/[id]/edit/page.js
@@ -11,7 +11,7 @@ import config from '@/config';
 export default function EditPortfolioPage() {
   const router = useRouter();
   const params = useParams();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -33,6 +33,7 @@ export default function EditPortfolioPage() {
   const portfolioId = params.id;
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -86,7 +87,7 @@ export default function EditPortfolioPage() {
     };
 
     fetchData();
-  }, [isAuthenticated, token, portfolioId, router]);
+  }, [authLoading, isAuthenticated, token, portfolioId, router]);
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;

--- a/src/frontend/src/app/portfolios/new/page.js
+++ b/src/frontend/src/app/portfolios/new/page.js
@@ -10,7 +10,7 @@ import config from '@/config';
 
 export default function NewPortfolioPage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [projects, setProjects] = useState([]);
@@ -28,6 +28,7 @@ export default function NewPortfolioPage() {
   const [selectedProjects, setSelectedProjects] = useState(new Set());
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -56,7 +57,7 @@ export default function NewPortfolioPage() {
     };
 
     fetchProjects();
-  }, [isAuthenticated, token, router]);
+  }, [authLoading, isAuthenticated, token, router]);
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;

--- a/src/frontend/src/app/portfolios/page.js
+++ b/src/frontend/src/app/portfolios/page.js
@@ -9,13 +9,14 @@ import { getPortfolios, deletePortfolio } from '@/utils/portfolioApi';
 
 export default function PortfoliosPage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [portfolios, setPortfolios] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [deletingId, setDeletingId] = useState(null);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -34,7 +35,7 @@ export default function PortfoliosPage() {
     };
 
     fetchPortfolios();
-  }, [isAuthenticated, token, router]);
+  }, [authLoading, isAuthenticated, token, router]);
 
   const handleDelete = async (portfolioId, portfolioTitle) => {
     if (!confirm(`Are you sure you want to delete "${portfolioTitle}"? This action cannot be undone.`)) {

--- a/src/frontend/src/app/profile/page.js
+++ b/src/frontend/src/app/profile/page.js
@@ -11,7 +11,7 @@ import config from '@/config';
 
 export default function ProfilePage() {
   const router = useRouter();
-  const { isAuthenticated, token, user, setCurrentUser } = useAuth();
+  const { isAuthenticated, token, user, setCurrentUser, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState({ type: '', text: '' });
@@ -44,6 +44,7 @@ export default function ProfilePage() {
   const [uploadingImage, setUploadingImage] = useState(false);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -79,7 +80,7 @@ export default function ProfilePage() {
     };
 
     fetchUser();
-  }, []);
+  }, [authLoading, isAuthenticated, token, router]);
 
   // Initialize button animations after component render with multiple delays to catch all buttons
   useEffect(() => {

--- a/src/frontend/src/app/projects/[id]/page.js
+++ b/src/frontend/src/app/projects/[id]/page.js
@@ -10,13 +10,14 @@ import config from '@/config';
 export default function ProjectDetailPage() {
   const router = useRouter();
   const params = useParams();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [project, setProject] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -50,7 +51,7 @@ export default function ProjectDetailPage() {
     if (params.id) {
       fetchProject();
     }
-  }, [isAuthenticated, token, router, params.id]);
+  }, [authLoading, isAuthenticated, token, router, params.id]);
 
   const handleDeleteProject = async () => {
     if (!confirm('Are you sure you want to delete this project? This action cannot be undone.')) {

--- a/src/frontend/src/app/projects/page.js
+++ b/src/frontend/src/app/projects/page.js
@@ -9,7 +9,7 @@ import config from '@/config';
 
 export default function ProjectsPage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -19,6 +19,7 @@ export default function ProjectsPage() {
   const [deletingProject, setDeletingProject] = useState(null);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -47,7 +48,7 @@ export default function ProjectsPage() {
     };
 
     fetchProjects();
-  }, [isAuthenticated, token, router]);
+  }, [authLoading, isAuthenticated, token, router]);
 
   const formatDate = (dateString) => {
     if (!dateString) return 'N/A';

--- a/src/frontend/src/app/resume/page.js
+++ b/src/frontend/src/app/resume/page.js
@@ -31,7 +31,7 @@ import styles from './resume.module.css';
 
 export default function ResumePage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState({ type: '', text: '' });
 
@@ -103,6 +103,7 @@ export default function ResumePage() {
 
   // Initialize page
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -208,7 +209,7 @@ export default function ResumePage() {
     };
 
     initializeResumePage();
-  }, [isAuthenticated, token, router]);
+  }, [authLoading, isAuthenticated, token, router]);
 
   // Undo/Redo functions
   const pushToHistory = (data) => {

--- a/src/frontend/src/app/resumes/page.js
+++ b/src/frontend/src/app/resumes/page.js
@@ -9,12 +9,13 @@ import styles from './resumes.module.css';
 
 export default function ResumesListPage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState({ type: '', text: '' });
   const [resumes, setResumes] = useState([]);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
@@ -23,7 +24,7 @@ export default function ResumesListPage() {
     // Note: This endpoint would need to be added to the backend
     // For now, we'll show a placeholder
     setLoading(false);
-  }, [isAuthenticated, token, router]);
+  }, [authLoading, isAuthenticated, token, router]);
 
   const handleNewResume = () => {
     router.push('/resume');

--- a/src/frontend/src/app/signup/page.js
+++ b/src/frontend/src/app/signup/page.js
@@ -10,7 +10,7 @@ import { initializeButtons } from '@/utils/buttonAnimation';
 
 export default function SignupPage() {
   const router = useRouter();
-  const { login: authLogin } = useAuth();
+  const { login: authLogin, isAuthenticated, loading: authLoading } = useAuth();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -19,8 +19,12 @@ export default function SignupPage() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      router.push('/dashboard');
+      return;
+    }
     initializeButtons();
-  }, []);
+  }, [authLoading, isAuthenticated, router]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/src/frontend/src/app/upload/page.js
+++ b/src/frontend/src/app/upload/page.js
@@ -9,7 +9,7 @@ import Toast from '@/components/Toast';
 
 export default function UploadPage() {
   const router = useRouter();
-  const { isAuthenticated, token } = useAuth();
+  const { isAuthenticated, token, loading: authLoading } = useAuth();
   const [selectedFile, setSelectedFile] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -18,11 +18,12 @@ export default function UploadPage() {
   const fileInputRef = useRef(null);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       router.push('/login');
       return;
     }
-  }, []);
+  }, [authLoading, isAuthenticated, router]);
 
   const handleDragOver = (e) => {
     e.preventDefault();

--- a/src/frontend/src/components/Header.js
+++ b/src/frontend/src/components/Header.js
@@ -8,7 +8,7 @@ import { useState, useEffect, useRef } from 'react';
 export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
-  const { user, logout } = useAuth();
+  const { user, logout, loading } = useAuth();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 

--- a/src/frontend/src/context/AuthContext.js
+++ b/src/frontend/src/context/AuthContext.js
@@ -4,17 +4,20 @@ import { createContext, useContext, useState, useEffect } from 'react';
 
 const AuthContext = createContext();
 
+function getInitialToken() {
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem('access_token') || null;
+  }
+  return null;
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
-  const [token, setToken] = useState(null);
+  const [token, setToken] = useState(getInitialToken);
   const [loading, setLoading] = useState(true);
 
-  // Load token from localStorage on mount
+  // Mark loading complete after mount
   useEffect(() => {
-    const storedToken = localStorage.getItem('access_token');
-    if (storedToken) {
-      setToken(storedToken);
-    }
     setLoading(false);
   }, []);
 

--- a/src/frontend/src/context/AuthContext.js
+++ b/src/frontend/src/context/AuthContext.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect } from 'react';
+import config from '@/config';
 
 const AuthContext = createContext();
 
@@ -16,15 +17,47 @@ export function AuthProvider({ children }) {
   const [token, setToken] = useState(getInitialToken);
   const [loading, setLoading] = useState(true);
 
-  // Mark loading complete after mount
+  // Fetch user information from the API
+  const fetchUserInfo = async (authToken) => {
+    try {
+      const response = await fetch(`${config.API_URL}/api/users/me/`, {
+        headers: {
+          'Authorization': `Bearer ${authToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setUser(data.user);
+      } else if (response.status === 401) {
+        // Token is invalid, logout
+        logout();
+      }
+    } catch (error) {
+      console.error('Failed to fetch user info:', error);
+    }
+  };
+
+  // Load user info if token exists on mount
   useEffect(() => {
-    setLoading(false);
+    const initializeAuth = async () => {
+      if (token) {
+        await fetchUserInfo(token);
+      }
+      setLoading(false);
+    };
+
+    initializeAuth();
   }, []);
 
-  const login = (accessToken, refreshToken) => {
+  const login = async (accessToken, refreshToken) => {
     setToken(accessToken);
     localStorage.setItem('access_token', accessToken);
     localStorage.setItem('refresh_token', refreshToken);
+    
+    // Fetch user info immediately after login
+    await fetchUserInfo(accessToken);
   };
 
   const logout = () => {


### PR DESCRIPTION
## 📝 Description

Fix page refresh redirecting to login 

Problem: 
Refreshing any authenticated page always redirected to /login because the token was loaded asynchronously via useEffect, causing a race condition where pages checked isAuthenticated before the token was read from localStorage. 

Fix: AuthContext now initializes the token synchronously from localStorage instead of waiting for useEffect

```js
// Before
const { isAuthenticated, token } = useAuth();
useEffect(() => {
  if (!isAuthenticated) { router.push('/login'); return; }
  // fetch data...
}, [isAuthenticated, token, router]);

// After
const { isAuthenticated, token, loading: authLoading } = useAuth();
useEffect(() => {
  if (authLoading) return;
  if (!isAuthenticated) { router.push('/login'); return; }
  // fetch data...
}, [authLoading, isAuthenticated, token, router]);
```
**Closes:** #300 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
 - visit webpage
 - login
 - go to dashboard
 - refresh page
 - login state should be same and check that you are not redirected

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
