### PR TITLE
Improve/frontend auto generate resume

### DIFF
--- a/src/frontend/src/__tests__/autoGenerateResume.test.js
+++ b/src/frontend/src/__tests__/autoGenerateResume.test.js
@@ -254,6 +254,17 @@ describe('selectTopSkills', () => {
   test('capitalizes skill names', () => {
     const projects = [makeProject({ languages: [{ id: 1, name: 'python' }] })];
     const result = selectTopSkills(projects, null);
+    expect(result[0].title).toBe('python');
+  });
+
+  test('preserves preferred casing from aggregated skills', () => {
+    const projects = [makeProject({ languages: [{ id: 1, name: 'python' }] })];
+    const agg = {
+      languages: [{ name: 'Python', project_count: 4 }],
+      frameworks: [],
+      resume_skills: [],
+    };
+    const result = selectTopSkills(projects, agg, 3);
     expect(result[0].title).toBe('Python');
   });
 
@@ -316,7 +327,12 @@ describe('buildProjectEntries', () => {
 
   test('handles project with no bullet points', () => {
     const entries = buildProjectEntries([projectE]);
-    expect(entries[0].content).toBe('');
+    expect(entries[0].content).toContain('• ');
+  });
+
+  test('builds stable project ids from project id', () => {
+    const entries = buildProjectEntries([projectA]);
+    expect(entries[0].id).toBe('auto-project-1');
   });
 
   test('handles project with no dates', () => {
@@ -393,6 +409,7 @@ describe('autoGenerateResume', () => {
     expect(result.sections.projects).toEqual([]);
     expect(result.sections.skills).toEqual([]);
     expect(result.name).toBe('Jane Doe');
+    expect(result.sections.summary.length).toBeGreaterThan(0);
   });
 
   test('works with no currentResumeData', () => {
@@ -436,7 +453,17 @@ describe('autoGenerateResume', () => {
       aggregatedSkills,
     });
     result.sections.skills.forEach((s) => {
-      expect(s.title[0]).toBe(s.title[0].toUpperCase());
+      expect(typeof s.title).toBe('string');
+      expect(s.title.length).toBeGreaterThan(0);
     });
+  });
+
+  test('generates summary when existing summary is blank', () => {
+    const result = autoGenerateResume({
+      currentResumeData: baseResumeData,
+      projects: allProjects,
+      aggregatedSkills,
+    });
+    expect(result.sections.summary.length).toBeGreaterThan(0);
   });
 });

--- a/src/frontend/src/utils/autoGenerateResume.js
+++ b/src/frontend/src/utils/autoGenerateResume.js
@@ -87,6 +87,15 @@ export function selectTopSkills(projects, aggregatedSkills, max = MAX_SKILLS) {
   const freq = {};
   const preferredName = {};
 
+  const shouldReplacePreferredName = (existing, candidate) => {
+    if (!existing) return true;
+    if (candidate.length > existing.length) return true;
+
+    const existingHasUpper = /[A-Z]/.test(existing);
+    const candidateHasUpper = /[A-Z]/.test(candidate);
+    return candidateHasUpper && !existingHasUpper;
+  };
+
   const trackSkill = (skillLike, count = 1) => {
     const rawName = typeof skillLike === 'string' ? skillLike : skillLike?.name;
     if (!rawName) return;
@@ -98,7 +107,7 @@ export function selectTopSkills(projects, aggregatedSkills, max = MAX_SKILLS) {
     freq[key] = (freq[key] || 0) + count;
 
     // Keep the most descriptive (usually title-cased) variant for display.
-    if (!preferredName[key] || normalized.length > preferredName[key].length) {
+    if (shouldReplacePreferredName(preferredName[key], normalized)) {
       preferredName[key] = normalized;
     }
   };
@@ -122,7 +131,7 @@ export function selectTopSkills(projects, aggregatedSkills, max = MAX_SKILLS) {
         const key = normalized.toLowerCase();
         const count = typeof s?.project_count === 'number' ? s.project_count : 1;
         freq[key] = Math.max(freq[key] || 0, count);
-        if (!preferredName[key] || normalized.length > preferredName[key].length) {
+        if (shouldReplacePreferredName(preferredName[key], normalized)) {
           preferredName[key] = normalized;
         }
       });


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Improved frontend resume auto-generation quality in the resume builder.

### What changed
- Updated project scoring to better prioritize meaningful and recent projects.
- Improved skill aggregation using languages, frameworks, and resume skills while reducing duplicates.
- Added safer timestamp handling for recency scoring.
- Added fallback project bullets so generated project sections are never empty.
- Added automatic summary generation only when summary is blank.
- Added stable generated project IDs for more predictable UI behavior.
- Updated and expanded unit tests for new auto-generation behavior.



**Closes:** #328 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing


- [x] Targeted unit test run:
	- `npx jest src/__tests__/autoGenerateResume.test.js --runInBand`
- [x] Manual checks 
	- Auto-generate preserves existing personal info/education/experience.
	- Projects with missing bullets now produce fallback content.
	- Empty summary now auto-populates; non-empty summary remains unchanged.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots



</details>
